### PR TITLE
Fix builds

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # 0.20-beta
 
-* *Nothing yet...*
+* Fixed: When publishing, `csproj` file is needed after 7.0.200
 
 # 0.19-beta
 

--- a/Source/Bake/Services/Tools/DotNet.cs
+++ b/Source/Bake/Services/Tools/DotNet.cs
@@ -255,6 +255,7 @@ namespace Bake.Services.Tools
             var arguments = new List<string>
                 {
                     "publish",
+                    "*.csproj",
                     "--configuration", argument.Configuration,
                     "--nologo",
                     "--output", argument.Output

--- a/Source/Bake/Services/Tools/DotNet.cs
+++ b/Source/Bake/Services/Tools/DotNet.cs
@@ -255,7 +255,7 @@ namespace Bake.Services.Tools
             var arguments = new List<string>
                 {
                     "publish",
-                    "*.csproj",
+                    argument.FilePath,
                     "--configuration", argument.Configuration,
                     "--nologo",
                     "--output", argument.Output

--- a/Source/Bake/Services/Tools/Go.cs
+++ b/Source/Bake/Services/Tools/Go.cs
@@ -117,6 +117,7 @@ namespace Bake.Services.Tools
                 {
                     ["GOOS"] = OsMap[os],
                     ["GOARCH"] = ArchMap[arch],
+                    ["CGO_ENABLED"] = "0"
                 };
         }
     }


### PR DESCRIPTION
When using `--output`, `csproj` file is needed as argument, see https://github.com/dotnet/sdk/issues/30625