### PR TITLE
Fix: AssemblyVersion should be properly set

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # 0.36
 
-* *Nothing yet...*
+* New: Dropped the `-beta` on Bake version, version `0.x` says as much 
+* Fix: `AssemblyVersion` must always be `[MAJOR].0.0.0` to limit assembly load errors
 
 # 0.35-beta
 

--- a/Source/Bake/Cooking/Composers/DotNetComposer.cs
+++ b/Source/Bake/Cooking/Composers/DotNetComposer.cs
@@ -369,8 +369,13 @@ namespace Bake.Cooking.Composers
             }
 
             var legacyVersion = ingredients.Version.LegacyVersion.ToString();
+
+            // CRITICAL for NuGet packages!
+            // Setting the AssemblyVersion to [MAJOR].0.0.0 ensures that the assembly version remains stable
+            // across minor and patch updates, which is important for binding redirects and compatibility.
+            properties["AssemblyVersion"] = $"{ingredients.Version.Major}.0.0.0";
+
             properties["Version"] = legacyVersion;
-            properties["AssemblyVersion"] = $"{ingredients.Version.Major}.0.0.0"; // CRITICAL for NuGet packages!
             properties["ApplicationVersion"] = legacyVersion;
             properties["FileVersion"] = legacyVersion;
             properties["AssemblyFileVersion"] = legacyVersion;

--- a/Source/Bake/Cooking/Composers/DotNetComposer.cs
+++ b/Source/Bake/Cooking/Composers/DotNetComposer.cs
@@ -252,6 +252,7 @@ namespace Bake.Cooking.Composers
                     Platform.Any,
                     path,
                     ingredients.Version,
+                    properties,
                     new DirectoryArtifact(
                         Path.Combine(visualStudioProject.Directory, path)));
 
@@ -293,6 +294,7 @@ namespace Bake.Cooking.Composers
                     targetPlatform,
                     path,
                     ingredients.Version,
+                    properties,
                     new ExecutableArtifact(
                         visualStudioProject.CsProj.ToolCommandName,
                         Path.Combine(
@@ -368,7 +370,9 @@ namespace Bake.Cooking.Composers
 
             var legacyVersion = ingredients.Version.LegacyVersion.ToString();
             properties["Version"] = legacyVersion;
-            properties["AssemblyVersion"] = legacyVersion;
+            properties["AssemblyVersion"] = $"{ingredients.Version.Major}.0.0.0"; // CRITICAL for NuGet packages!
+            properties["ApplicationVersion"] = legacyVersion;
+            properties["FileVersion"] = legacyVersion;
             properties["AssemblyFileVersion"] = legacyVersion;
             properties["Description"] = BuildDescription(visualStudioSolution, ingredients);
 

--- a/Source/Bake/Cooking/Cooks/DotNet/DotNetPublishCook.cs
+++ b/Source/Bake/Cooking/Cooks/DotNet/DotNetPublishCook.cs
@@ -20,8 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Threading;
-using System.Threading.Tasks;
 using Bake.Services.Tools;
 using Bake.Services.Tools.DotNetArguments;
 using Bake.ValueObjects.Recipes.DotNet;
@@ -51,7 +49,8 @@ namespace Bake.Cooking.Cooks.DotNet
                 recipe.Configuration,
                 recipe.Platform,
                 recipe.Output,
-                recipe.Version);
+                recipe.Version,
+                recipe.Properties);
 
             using var toolResult = await _dotNet.PublishAsync(
                 argument,

--- a/Source/Bake/Services/Tools/DotNet.cs
+++ b/Source/Bake/Services/Tools/DotNet.cs
@@ -135,15 +135,10 @@ namespace Bake.Services.Tools
                      "--configuration", argument.Configuration,
                 };
 
-            foreach (var (property, value) in argument.Properties)
-            {
-                arguments.Add($"-p:{property}={value.ToMsBuildEscaped()}");
-            }
+            arguments.AddRange(AsPropertyArguments(argument.Properties));
 
             AddIf(!argument.Incremental, arguments, "--no-incremental");
             AddIf(!argument.Restore, arguments, "--no-restore");
-
-            arguments.AddRange(VersionArguments(argument.Version));
 
             var buildRunner = _runnerFactory.CreateRunner(
                 "dotnet",
@@ -154,6 +149,14 @@ namespace Bake.Services.Tools
             var runnerResult = await buildRunner.ExecuteAsync(cancellationToken);
 
             return new ToolResult(runnerResult);
+        }
+
+        private static IEnumerable<string> AsPropertyArguments(IReadOnlyDictionary<string, string> properties)
+        {
+            foreach (var (property, value) in properties)
+            {
+                yield return $"-p:{property}={value.ToMsBuildEscaped()}";
+            }
         }
 
         public async Task<IToolResult> TestAsync(
@@ -262,22 +265,18 @@ namespace Bake.Services.Tools
                     "--configuration", argument.Configuration,
                     "--nologo",
                     "--output", argument.Output,
-                    "-p:CheckEolTargetFramework=false"
                 };
 
             if (argument.Platform.Os != ExecutableOperatingSystem.Any)
             {
-                arguments.AddRange(new []
-                    {
-                        "--runtime", argument.Platform.GetDotNetRuntimeIdentifier()
-                    });
+                arguments.AddRange(["--runtime", argument.Platform.GetDotNetRuntimeIdentifier()]);
             }
+
+            arguments.AddRange(AsPropertyArguments(argument.Properties));
 
             AddIf(!argument.Build, arguments, "--no-build");
             AddIf(argument.PublishSingleFile, arguments, "-p:PublishSingleFile=true");
             AddIf(argument.SelfContained, arguments, "--self-contained", "true");
-
-            arguments.AddRange(VersionArguments(argument.Version));
 
             var buildRunner = _runnerFactory.CreateRunner(
                 "dotnet",
@@ -288,14 +287,6 @@ namespace Bake.Services.Tools
             var runnerResult = await buildRunner.ExecuteAsync(cancellationToken);
 
             return new ToolResult(runnerResult);
-        }
-
-        private static IEnumerable<string> VersionArguments(SemVer version)
-        {
-            yield return $"-p:Version={version}";
-            yield return $"-p:ApplicationVersion={version}";
-            yield return $"-p:AssemblyVersion={version.LegacyVersion}";
-            yield return $"-p:FileVersion={version.LegacyVersion}";
         }
     }
 }

--- a/Source/Bake/Services/Tools/DotNetArguments/DotNetPublishArgument.cs
+++ b/Source/Bake/Services/Tools/DotNetArguments/DotNetPublishArgument.cs
@@ -34,6 +34,7 @@ namespace Bake.Services.Tools.DotNetArguments
         public Platform Platform { get; }
         public string Output { get; }
         public SemVer Version { get; }
+        public IReadOnlyDictionary<string, string> Properties { get; }
 
         public DotNetPublishArgument(
             string filePath,
@@ -43,7 +44,8 @@ namespace Bake.Services.Tools.DotNetArguments
             string configuration,
             Platform platform,
             string output,
-            SemVer version)
+            SemVer version,
+            IReadOnlyDictionary<string, string> properties)
             : base(filePath)
         {
             PublishSingleFile = publishSingleFile;
@@ -53,6 +55,7 @@ namespace Bake.Services.Tools.DotNetArguments
             Platform = platform;
             Output = output;
             Version = version;
+            Properties = properties;
         }
     }
 }

--- a/Source/Bake/ValueObjects/Recipes/DotNet/DotNetPublishRecipe.cs
+++ b/Source/Bake/ValueObjects/Recipes/DotNet/DotNetPublishRecipe.cs
@@ -53,6 +53,9 @@ namespace Bake.ValueObjects.Recipes.DotNet
         [YamlMember]
         public SemVer Version { get; [Obsolete] set; } = null!;
 
+        [YamlMember]
+        public Dictionary<string, string> Properties { get; [Obsolete] set; } = null!;
+
         [Obsolete]
         public DotNetPublishRecipe() { }
 
@@ -65,6 +68,7 @@ namespace Bake.ValueObjects.Recipes.DotNet
             Platform platform,
             string output,
             SemVer version,
+            Dictionary<string, string> properties,
             params Artifact[] artifacts)
             : base(artifacts)
         {
@@ -77,6 +81,7 @@ namespace Bake.ValueObjects.Recipes.DotNet
             Platform = platform;
             Output = output;
             Version = version;
+            Properties = properties;
 #pragma warning restore CS0612 // Type or member is obsolete
         }
     }


### PR DESCRIPTION
This pull request includes several changes aimed at improving version handling and adding properties support to the .NET build and publish processes. The most important changes include updates to the `AssemblyVersion` handling, the addition of properties to various methods and classes, and the refactoring of argument handling in the `DotNet` service.