### PR TITLE
Fix dependent DLL bundling

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 # 0.40
 
-* _Nothing yet_
+* Fix: GitHub release ZIPs for .NET tools now include native DLLs from the
+  publish output directory, ensuring tools with native dependencies (e.g.,
+  LibGit2Sharp) are functional
+* Fix: Go release ZIP filenames no longer contain path separators
 
 # 0.39
 

--- a/Source/Bake.Tests/ExplicitTests/GitHubReleaseCookTests.cs
+++ b/Source/Bake.Tests/ExplicitTests/GitHubReleaseCookTests.cs
@@ -56,7 +56,8 @@ namespace Bake.Tests.ExplicitTests
                 {
                     new ExecutableArtifact(
                         "test_linux",
-                        Path.Combine(WorkingDirectory, "README.md"),
+                        WorkingDirectory,
+                        "README.md",
                         new Platform(ExecutableOperatingSystem.Linux, ExecutableArchitecture.Intel64))
                 });
 

--- a/Source/Bake/Cooking/Composers/DotNetComposer.cs
+++ b/Source/Bake/Cooking/Composers/DotNetComposer.cs
@@ -321,6 +321,11 @@ namespace Bake.Cooking.Composers
                     "publish",
                     targetPlatform.GetDotNetRuntimeIdentifier());
 
+                var outputDirectory = Path.Combine(visualStudioProject.Directory, path);
+                var executableFileName = targetPlatform.Os == ExecutableOperatingSystem.Windows
+                    ? $"{visualStudioProject.AssemblyName}.exe"
+                    : visualStudioProject.AssemblyName;
+
                 yield return new DotNetPublishRecipe(
                     visualStudioProject.Path,
                     true,
@@ -333,12 +338,8 @@ namespace Bake.Cooking.Composers
                     properties,
                     new ExecutableArtifact(
                         visualStudioProject.CsProj.ToolCommandName,
-                        Path.Combine(
-                            visualStudioProject.Directory,
-                            path,
-                            targetPlatform.Os == ExecutableOperatingSystem.Windows
-                                ? $"{visualStudioProject.AssemblyName}.exe"
-                                : visualStudioProject.AssemblyName),
+                        outputDirectory,
+                        executableFileName,
                         targetPlatform));
             }
         }

--- a/Source/Bake/Cooking/Composers/GoComposer.cs
+++ b/Source/Bake/Cooking/Composers/GoComposer.cs
@@ -120,17 +120,20 @@ namespace Bake.Cooking.Composers
             recipes.AddRange(context.Ingredients.Platforms
                 .Select(p =>
                 {
-                    var output = p.Os == ExecutableOperatingSystem.Windows
-                        ? Path.Combine(p.GetSlug(), windowsOutput)
-                        : Path.Combine(p.GetSlug(), goModuleName.Name);
+                    var executableFileName = p.Os == ExecutableOperatingSystem.Windows
+                        ? windowsOutput
+                        : goModuleName.Name;
+                    var output = Path.Combine(p.GetSlug(), executableFileName);
+                    var outputDirectory = Path.Combine(directoryPath, p.GetSlug());
 
                     return new GoBuildRecipe(
                         output,
                         directoryPath,
                         p,
                         new ExecutableArtifact(
-                            output,
-                            Path.Combine(directoryPath, output),
+                            goModuleName.Name,
+                            outputDirectory,
+                            executableFileName,
                             p));
                 }));
 

--- a/Source/Bake/Cooking/Cooks/GitHub/GitHubReleaseCook.cs
+++ b/Source/Bake/Cooking/Cooks/GitHub/GitHubReleaseCook.cs
@@ -186,14 +186,16 @@ namespace Bake.Cooking.Cooks.GitHub
                 .OfType<ExecutableArtifact>()
                 .Select(async artifact =>
                 {
-                    var file = _fileSystem.Open(artifact.Path);
+                    var publishedFiles = System.IO.Directory.GetFiles(artifact.Directory)
+                        .Select(f => _fileSystem.Open(f))
+                        .ToArray();
                     var fileName = CalculateArtifactFileName(artifact);
                     var compressedFile = await _fileSystem.CompressAsync(
                         fileName,
                         CompressionAlgorithm.ZIP,
                         Enumerable.Empty<IFile>()
                             .Concat(additionalFiles)
-                            .Concat(new[] {file,})
+                            .Concat(publishedFiles)
                             .ToArray(),
                         cancellationToken);
                     var sha256 = await compressedFile.GetHashAsync(

--- a/Source/Bake/ValueObjects/Artifacts/ExecutableArtifact.cs
+++ b/Source/Bake/ValueObjects/Artifacts/ExecutableArtifact.cs
@@ -1,17 +1,17 @@
 // MIT License
-// 
+//
 // Copyright (c) 2021-2026 Rasmus Mikkelsen
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,7 +25,7 @@ using YamlDotNet.Serialization;
 namespace Bake.ValueObjects.Artifacts
 {
     [Artifact(Names.Artifacts.ExecutableArtifact)]
-    public class ExecutableArtifact : FileArtifact
+    public class ExecutableArtifact : Artifact
     {
         [YamlMember]
         public string Name { get; [Obsolete] set; } = null!;
@@ -33,19 +33,53 @@ namespace Bake.ValueObjects.Artifacts
         [YamlMember]
         public Platform Platform { get; [Obsolete] set; } = null!;
 
+        [YamlMember]
+        public string Directory { get; [Obsolete] set; } = null!;
+
+        [YamlMember]
+        public string ExecutableFileName { get; [Obsolete] set; } = null!;
+
+        public string ExecutablePath => Path.Combine(Directory, ExecutableFileName);
+
         [Obsolete]
         public ExecutableArtifact() { }
 
         public ExecutableArtifact(
             string name,
-            string path,
+            string directory,
+            string executableFileName,
             Platform platform)
-            : base(path)
         {
 #pragma warning disable CS0612 // Type or member is obsolete
             Name = name;
+            Directory = directory;
+            ExecutableFileName = executableFileName;
             Platform = platform;
 #pragma warning restore CS0612 // Type or member is obsolete
+        }
+
+        public override IAsyncEnumerable<string> ValidateAsync(
+            /*[EnumeratorCancellation]*/ CancellationToken _)
+        {
+            if (!System.IO.Directory.Exists(Directory))
+                return AsyncEnumerable.Repeat($"Directory {Directory} does not exist", 1);
+            if (!File.Exists(ExecutablePath))
+                return AsyncEnumerable.Repeat($"Executable {ExecutablePath} does not exist", 1);
+            return AsyncEnumerable.Empty<string>();
+        }
+
+        public override IEnumerable<string> PrettyNames()
+        {
+            var relativePath = Path.GetRelativePath(
+                System.IO.Directory.GetCurrentDirectory(),
+                ExecutablePath);
+
+            yield return $"{ExecutableFileName} ({relativePath})";
+        }
+
+        public override string ToString()
+        {
+            return $"{GetType().Name}: {ExecutablePath}";
         }
     }
 }


### PR DESCRIPTION
## Summary

  - Redesign `ExecutableArtifact` from a single-file model (`FileArtifact`) to a directory-based model, storing the output directory and executable filename
   separately
  - `GitHubReleaseCook` now includes all files from the publish output directory in release ZIPs, ensuring native DLLs (e.g., LibGit2Sharp's `git2-*`) are
  packaged alongside the executable
  - Fix Go artifact naming — `Name` was set to a path with slashes (e.g., `linux-x64/myapp`), producing malformed ZIP filenames; now set to just the logical
   tool name

  ## Motivation

  When publishing a .NET `PackAsTool` project as a self-contained single-file executable, `dotnet publish` places native/unmanaged DLLs alongside the binary
   in the output directory. The previous implementation only included the single executable file in the GitHub release ZIP, silently dropping the native
  dependencies and producing a non-functional release.