### PR TITLE
Add macOS ARM64 as default platform target

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+# 0.41
+
+* New: macOS ARM64 (`osx-arm64`) is now a default platform target for tool
+  builds, alongside `win-x64`, `linux-x64`, and `osx-x64`
+* Fix: GitHub release filename generation now supports ARM64 architecture,
+  preventing a crash when releasing ARM64 artifacts
+
 # 0.40
 
 * Fix: GitHub release ZIPs for .NET tools now include native DLLs from the

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,8 @@
 # 0.41
 
-* New: macOS ARM64 (`osx-arm64`) is now a default platform target for tool
-  builds, alongside `win-x64`, `linux-x64`, and `osx-x64`
+* New: Default macOS platform target changed from `osx-x64` to `osx-arm64`
+  (Apple Silicon). Users on Intel Macs can still target `osx-x64` via
+  `--target-platform`
 * Fix: GitHub release filename generation now supports ARM64 architecture,
   preventing a crash when releasing ARM64 artifacts
 

--- a/Source/Bake.Tests/IntegrationTests/BakeTests/GoLangServiceTests.cs
+++ b/Source/Bake.Tests/IntegrationTests/BakeTests/GoLangServiceTests.cs
@@ -56,10 +56,6 @@ namespace Bake.Tests.IntegrationTests.BakeTests
                 "golang-service");
             AssertFileExists(
                 1L.MB(),
-                "osx-x64",
-                "golang-service");
-            AssertFileExists(
-                1L.MB(),
                 "osx-arm64",
                 "golang-service");
             AssertFileExists(

--- a/Source/Bake.Tests/IntegrationTests/BakeTests/GoLangServiceTests.cs
+++ b/Source/Bake.Tests/IntegrationTests/BakeTests/GoLangServiceTests.cs
@@ -60,6 +60,10 @@ namespace Bake.Tests.IntegrationTests.BakeTests
                 "golang-service");
             AssertFileExists(
                 1L.MB(),
+                "osx-arm64",
+                "golang-service");
+            AssertFileExists(
+                1L.MB(),
                 "win-x64",
                 "golang-service.exe");
 

--- a/Source/Bake.Tests/IntegrationTests/BakeTests/NetCoreConsoleTests.cs
+++ b/Source/Bake.Tests/IntegrationTests/BakeTests/NetCoreConsoleTests.cs
@@ -133,9 +133,6 @@ namespace Bake.Tests.IntegrationTests.BakeTests
                 "bin", "Release", "publish", "win-x64", "NetCore.Console.exe");
             AssertFileExists(
                 50L.MB(),
-                "bin", "Release", "publish", "osx-x64", "NetCore.Console");
-            AssertFileExists(
-                50L.MB(),
                 "bin", "Release", "publish", "osx-arm64", "NetCore.Console");
         }
 

--- a/Source/Bake.Tests/IntegrationTests/BakeTests/NetCoreConsoleTests.cs
+++ b/Source/Bake.Tests/IntegrationTests/BakeTests/NetCoreConsoleTests.cs
@@ -131,6 +131,12 @@ namespace Bake.Tests.IntegrationTests.BakeTests
             AssertFileExists(
                 50L.MB(),
                 "bin", "Release", "publish", "win-x64", "NetCore.Console.exe");
+            AssertFileExists(
+                50L.MB(),
+                "bin", "Release", "publish", "osx-x64", "NetCore.Console");
+            AssertFileExists(
+                50L.MB(),
+                "bin", "Release", "publish", "osx-arm64", "NetCore.Console");
         }
 
         [TestCase(ExitCodes.Core.NoCommand)]

--- a/Source/Bake.Tests/UnitTests/Services/PlatformParserTests.cs
+++ b/Source/Bake.Tests/UnitTests/Services/PlatformParserTests.cs
@@ -32,6 +32,8 @@ namespace Bake.Tests.UnitTests.Services
     {
         [TestCase("win/x86", ExecutableOperatingSystem.Windows, ExecutableArchitecture.Intel32)]
         [TestCase("linux/x64", ExecutableOperatingSystem.Linux, ExecutableArchitecture.Intel64)]
+        [TestCase("mac/arm64", ExecutableOperatingSystem.MacOSX, ExecutableArchitecture.Arm64)]
+        [TestCase("macos/arm64", ExecutableOperatingSystem.MacOSX, ExecutableArchitecture.Arm64)]
         public void Success(
             string str,
             ExecutableOperatingSystem executableOs,

--- a/Source/Bake/Cooking/Cooks/GitHub/GitHubReleaseCook.cs
+++ b/Source/Bake/Cooking/Cooks/GitHub/GitHubReleaseCook.cs
@@ -46,6 +46,7 @@ namespace Bake.Cooking.Cooks.GitHub
             {
                 [ExecutableArchitecture.Intel32] = "x86",
                 [ExecutableArchitecture.Intel64] = "x86_64",
+                [ExecutableArchitecture.Arm64] = "arm64",
             };
 
         private readonly ILogger<GitHubReleaseCook> _logger;

--- a/Source/Bake/ValueObjects/Platform.cs
+++ b/Source/Bake/ValueObjects/Platform.cs
@@ -27,11 +27,12 @@ namespace Bake.ValueObjects
 {
     public class Platform
     {
-        public static Platform[] Defaults { get; } = 
+        public static Platform[] Defaults { get; } =
             {
                 new(ExecutableOperatingSystem.Windows, ExecutableArchitecture.Intel64),
                 new(ExecutableOperatingSystem.Linux, ExecutableArchitecture.Intel64),
                 new(ExecutableOperatingSystem.MacOSX, ExecutableArchitecture.Intel64),
+                new(ExecutableOperatingSystem.MacOSX, ExecutableArchitecture.Arm64),
             };
         public static Platform Any { get; } = new(ExecutableOperatingSystem.Any, ExecutableArchitecture.Any);
 

--- a/Source/Bake/ValueObjects/Platform.cs
+++ b/Source/Bake/ValueObjects/Platform.cs
@@ -31,7 +31,6 @@ namespace Bake.ValueObjects
             {
                 new(ExecutableOperatingSystem.Windows, ExecutableArchitecture.Intel64),
                 new(ExecutableOperatingSystem.Linux, ExecutableArchitecture.Intel64),
-                new(ExecutableOperatingSystem.MacOSX, ExecutableArchitecture.Intel64),
                 new(ExecutableOperatingSystem.MacOSX, ExecutableArchitecture.Arm64),
             };
         public static Platform Any { get; } = new(ExecutableOperatingSystem.Any, ExecutableArchitecture.Any);

--- a/TestProjects/NetCore.Console/NetCore.Console.csproj
+++ b/TestProjects/NetCore.Console/NetCore.Console.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PackageId>awesome-cli-tool</PackageId>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTool>true</IsTool>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>magic-command</ToolCommandName>

--- a/TestProjects/NetCore.Console/NetCore.Console.csproj
+++ b/TestProjects/NetCore.Console/NetCore.Console.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PackageId>awesome-cli-tool</PackageId>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsTool>true</IsTool>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>magic-command</ToolCommandName>


### PR DESCRIPTION
Add osx-arm64 to Platform.Defaults so tools are built for Apple Silicon by default. Also add Arm64 to GitHubReleaseCook.NamingArch to prevent KeyNotFoundException when creating release filenames for ARM64 artifacts.